### PR TITLE
Update .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,19 +1,12 @@
-# renovate: datasource=github-tags depName=npryce/adr-tools
 adr-tools 3.0.0
 awscli 2.11.27
-# renovate: datasource=github-tags depName=bridgecrewio/checkov
 checkov 2.3.234
 golang 1.20.5
-# renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.53.2
-# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.3.3
 terraform 1.5.0
-# renovate: datasource=github-tags depName=terraform-docs/terraform-docs
 terraform-docs 0.16.0
-# renovate: datasource=github-tags depName=terraform-linters/tflint
 tflint 0.46.1
-# renovate: datasource=github-tags depName=aquasecurity/tfsec
 tfsec 1.28.1
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
 zarf 0.27.1


### PR DESCRIPTION
Renovate supports these tools natively now so they don't need custom RegexManager strings. See https://docs.renovatebot.com/modules/manager/asdf/.