### PR TITLE
Change renovate rebaseWhen to never

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,8 +21,8 @@
     "after 7am and before 9am every weekday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
-  // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen
-  rebaseWhen: "conflicted",
+  // See https://docs.renovatebot.com/configuration-options/#rebasewhen
+  rebaseWhen: "never",
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [
     "renovate"


### PR DESCRIPTION
Renovate likes to force push commits which causes us to have to run tests more than should be needed. This will stop that.